### PR TITLE
Add documentation for automated cold-standby backups

### DIFF
--- a/docs/b_n_r-coldstandby.md
+++ b/docs/b_n_r-coldstandby.md
@@ -69,3 +69,30 @@ bash /opt/mailcow-dockerized/create_cold_standby.sh
 
 It's the same command.
 
+## Automated backups with cron
+
+First make sure that the `cron` service is enabled and running:
+
+```
+systemctl enable cron.service && systemctl start cron.service
+```
+
+To automate the backups to the cold-standby server you can use a cron job. To edit the cron jobs for the root user run:
+
+```
+crontab -e
+```
+
+Add the following lines to synchronize the cold standby server daily at 03:00. In this example errors of the last execution are logged into a file.
+
+```
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+0 3 * * * bash /opt/mailcow-dockerized/create_cold_standby.sh 2> /var/log/mailcow-coldstandby-sync.log
+```
+
+If saved correctly, the cron job should be shown by typing:
+
+```
+crontab -l
+```


### PR DESCRIPTION
In a default Ubuntu 20.04 installation the PATH variable in the `cron` service was missing the path `/usr/local/bin` for the `docker-compose` software. It always failed with `Cannot find docker-compose in local PATH, exiting`. To avoid troubleshooting for other users I added an example to automate cold-standby backups via cron.